### PR TITLE
1.2.4 updates

### DIFF
--- a/files/css/element.css
+++ b/files/css/element.css
@@ -7,6 +7,7 @@
 
 .callout-box-wrapper {
     padding: 20px 0px;
+    word-wrap: break-word;
 }
 
 .callout-box {

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest": "1",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "elements": [
     {
       "name": "Call-Out Box",
       "path": "files",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "settings": {
         "config": {
           "autopop": false


### PR DESCRIPTION
@rchen1992 @kiastu 

adds a `word-wrap: break-word;` css rule to allow long strings on mobile to wrap. 